### PR TITLE
All pathogens deselected now yields an empty map.

### DIFF
--- a/contexts/arbo-context/filter-update-steps/apply-new-selected-filters.tsx
+++ b/contexts/arbo-context/filter-update-steps/apply-new-selected-filters.tsx
@@ -11,6 +11,12 @@ export function filterData(
 
   return data.filter((item: any) => {
     return filterKeys.every((key: string) => {
+      /* If no pathogen is selected, we don't want to see any data */
+      if (key === "pathogen"){
+        if(filters[key].length == 0){
+          return false;
+        }
+      }
       if (!filters[key].length) return true;
 
       if (key === "end_date") {


### PR DESCRIPTION
The problem: when a filter is empty, it defaults to yielding true. This makes sense for most of the other filters, but for pathogen specifically this is illogical. So now, if pathogen is empty, we return false for that particular filter (since all the pathogens are preselected as filters). 

To check: go in and deselect all pathogens with any filter combo.