### PR TITLE
Reduced minimum cluster size for map clusters from 10 to 2

### DIFF
--- a/components/ui/pathogen-map/pathogen-map-layer.tsx
+++ b/components/ui/pathogen-map/pathogen-map-layer.tsx
@@ -50,7 +50,7 @@ export function PathogenMapSourceAndLayer<
       data={geojsonData}
       cluster
       clusterMaxZoom={6}
-      clusterMinPoints={10}
+      clusterMinPoints={2}
       clusterRadius={100}
       clusterProperties={clusterProperties}
     >


### PR DESCRIPTION
Resolves #168. Reduced minimum cluster size for map clusters from 10 to 2. Looks fine imo.

![image](https://github.com/serotracker/dashboard/assets/86806388/d553624f-eea5-4916-92d1-583147340955)
![Peek 2024-03-23 20-38](https://github.com/serotracker/dashboard/assets/86806388/7bb9708d-43a8-48ad-a2c9-7baf622a379d)
