### PR TITLE
Made all cases of what would be 0.0 render as N/A.

### DIFF
--- a/app/pathogen/arbovirus/dashboard/(table)/columns.tsx
+++ b/app/pathogen/arbovirus/dashboard/(table)/columns.tsx
@@ -129,11 +129,11 @@ export const columns: DataTableColumnDef<Estimate, unknown>[] = [
     header: get_header("Seroprevalence"),
     cell: ({ row }) => {
       const seroprevalence = row.getValue("seroprevalence");
-      if (typeof seroprevalence === 'number') {
+      if (typeof seroprevalence === 'number' && seroprevalence*100 >= 0.05) {
         return `${(seroprevalence * 100).toFixed(1)}%`;
       } else if (typeof seroprevalence === 'string') {
         const seroprevalenceNumber = parseFloat(seroprevalence);
-        if (!isNaN(seroprevalenceNumber)) {
+        if (!isNaN(seroprevalenceNumber) && seroprevalenceNumber*100 >= 0.05) {
           return `${(seroprevalenceNumber * 100).toFixed(1)}%`;
         }
       }


### PR DESCRIPTION
Sort by Seroprevelance in the table, and away you go. I'm worried that some of these cases may actually be legit 0.0's and some others may not be, but that is more of a data cleaning question then anything else. I have done as the ticket asks!

Closes #216.

<img width="554" alt="image" src="https://github.com/serotracker/dashboard/assets/25645374/79b2a3bd-56e5-40e1-a78a-718c7f0e17b0">
