### PR TITLE
Slight revisions on about page copy. Enables "About" page in production.

### DIFF
--- a/app/about/about-our-data/page.tsx
+++ b/app/about/about-our-data/page.tsx
@@ -15,8 +15,8 @@ export default function DataExtractionPage() {
       <Sponsors className="mb-4" />
       <div className='mb-4'>
         <p className="inline">SeroTracker is supported by the </p>
-        <Link className="inline text-link" href="https://www.canada.ca/en/public-health.html" target="__blank" rel="noopener noreferrer">Public Health Agency of Canada </Link>
-        <p className="inline">through the </p>
+        <Link className="inline text-link" href="https://www.canada.ca/en/public-health.html" target="__blank" rel="noopener noreferrer">Public Health Agency of Canada</Link>
+        <p className="inline"> through the </p>
         <Link className="inline text-link" href="https://www.covid19immunitytaskforce.ca/" target="__blank" rel="noopener noreferrer">COVID-19 Immunity Task Force</Link>
         <p className="inline">. SeroTracker is also hosted at the </p>
         <Link className="inline text-link" href="https://cumming.ucalgary.ca/centres/centre-health-informatics" target="__blank" rel="noopener noreferrer">University of Calgary&apos;s Centre for Health Informatics</Link>
@@ -24,14 +24,27 @@ export default function DataExtractionPage() {
       </div>
       <div className='mb-4'>
         <p className="inline">SeroTracker is working with the </p>
-        <Link className="inline text-link" href="https://www.who.int/" target="__blank" rel="noopener noreferrer">World Health Organization </Link>
-        <p className="inline">to visualize and synthesize results from the </p>
+        <Link className="inline text-link" href="https://www.who.int/" target="__blank" rel="noopener noreferrer">World Health Organization</Link>
+        <p className="inline"> to visualize and synthesize results from the </p>
         <Link className="inline text-link" href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/technical-guidance/early-investigations" target="__blank" rel="noopener noreferrer">Unity seroprevalence studies</Link>
         <p className="inline">. SeroTracker and the World Health Organization are grateful for German Federal Ministry of Health (BMG) COVID-19 Research and Development funding to support this effort. </p>
       </div>
       <div className="mb-4">
         <Link className="inline text-link" href="https://www.mapbox.com/" target="__blank" rel="noopener noreferrer">Mapbox </Link>
         <p className='mb-4 inline'>supports SeroTracker&apos;s mapping infrastructure.</p>
+      </div>
+      <h2 className={headerClassname}>New dashboard: ArboTracker </h2>
+      <div className="mb-4">
+        <p className='inline'> ArboTracker data was collected through a systematic review of published arbovirus seroprevalence studies in collaboration with partners at the </p>
+        <Link className='inline text-link' href='https://coloradosph.cuanschutz.edu/research-and-practice/centers-programs/globalhealth/research-projects/arbovirus-research-consortium' target="__blank" rel="noopener noreferrer">Arbovirus Research Consortium</Link>
+        <p className='inline'> at the Colorado School of Public Health and Heidelberg University. The search feeding the current dashboard was conducted on March 13, 2023. Data was extracted by researchers at Heidelberg University for each source&apos;s estimate(s) and certain relevant subgroups. Additional relevant data was extracted by researchers at SeroTracker. Full methods are available in </p>
+        <Link className='inline text-link' href='https://docs.google.com/document/d/1bdePf81TemPkRqfOKWA4z3-Le0TSbl4BrZ8jTVD5IiE/edit?usp=sharing' target="__blank" rel="noopener noreferrer">our protocol</Link>
+        <p className='inline'>.</p>
+      </div>
+      <div className="mb-4">
+        <p className='inline'> We produce data for both academic and public use on our dashboard. We aim to update our search strategy and dashboard in May 2024 to capture additional data. For further information beyond the following high-level summary, please see our </p>
+        <Link className='inline text-link' href='https://docs.google.com/document/d/1bdePf81TemPkRqfOKWA4z3-Le0TSbl4BrZ8jTVD5IiE/edit?usp=sharing' target="__blank" rel="noopener noreferrer">study protocol</Link>
+        <p className='inline'> for a detailed explanation of our research processes. </p>
       </div>
       <h2 className={headerClassname}>Contact Us</h2>
       <div className="mb-4">
@@ -45,19 +58,10 @@ export default function DataExtractionPage() {
       </div>
       <div className="mb-4">
         <p className='inline'>To make us aware of new arbovirus seroprevalence studies or arbovirus studies that we have not yet captured, please fill out </p>
-        <Link className='inline text-link' href='https://forms.gle/pKNiMiMYr6hiKnXx8'>this form.</Link>
-        <p className='inline'>For SARS-CoV-2 submissions, please use </p>
-        <Link className='inline text-link' href='https://docs.google.com/forms/d/e/1FAIpQLSdvNJReektutfMT-5bOTjfnvaY_pMAy8mImpQBAW-3v7_B2Bg/viewform'>this form</Link>
+        <Link className='inline text-link' href='https://forms.gle/pKNiMiMYr6hiKnXx8' target="__blank" rel="noopener noreferrer">this form.</Link>
+        <p className='inline'> For SARS-CoV-2 submissions, please use </p>
+        <Link className='inline text-link' href='https://docs.google.com/forms/d/e/1FAIpQLSdvNJReektutfMT-5bOTjfnvaY_pMAy8mImpQBAW-3v7_B2Bg/viewform' target="__blank" rel="noopener noreferrer">this form</Link>
         <p className='inline'> - however please see our FAQ for our frequency of data updates for this dataset.</p>
-      </div>
-      <h2 className={headerClassname}>About ArboTracker</h2>
-      <div className="mb-4">
-        <p> ArboTracker data was collected through a systematic review of published arbovirus seroprevalence studies in collaboration with partners at the University of Colorado and Heidelberg University. The search feeding the current dashboard was conducted on March 13, 2023. Data was extracted by researchers at Heidelberg University for each source&apos;s estimate(s) and certain relevant subgroups. Additional relevant data was extracted by researchers at SeroTracker. Full methods are available in our protocol. </p>
-      </div>
-      <div className="mb-4">
-        <p className='inline'> We produce data for both academic and public use on our dashboard. We aim to update our search strategy and dashboard in May 2024 to capture additional data. For further information beyond the following high-level summary, please see our </p>
-        <Link className='inline text-link' href='https://docs.google.com/document/d/1bdePf81TemPkRqfOKWA4z3-Le0TSbl4BrZ8jTVD5IiE/edit?usp=sharing'>study protocol</Link>
-        <p className='inline'> and supplementary methods for a detailed explanation of our research processes. </p>
       </div>
     </>
   );

--- a/app/about/faq/text.tsx
+++ b/app/about/faq/text.tsx
@@ -13,7 +13,7 @@ export enum FAQPageOptionId {
 export const faqPageText: Record<FAQPageOptionId, {label: string, content: JSX.Element}> = {
   [FAQPageOptionId.HOW_DOES_SEROTRACKER_COLLECT_THEIR_DATA]: {
     label: 'How does SeroTracker collect their data?',
-    content: <p className='inline'> We conduct ad-hoc searches of several databases including Medline, EMBASE, Web of Science, and Europe PMC and targeted google searches. In addition, anyone can submit studies for us to screen and include in our review by filling out <Link className="inline text-link underline" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSdvNJReektutfMT-5bOTjfnvaY_pMAy8mImpQBAW-3v7_B2Bg/viewform">this form</Link>. </p>
+    content: <p className='inline'> We conduct ad-hoc searches of several databases including Medline, EMBASE, Web of Science, and Europe PMC and targeted google searches. In addition, anyone can submit studies for us to screen and include in our review by filling out <Link className="inline text-link underline" target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdvNJReektutfMT-5bOTjfnvaY_pMAy8mImpQBAW-3v7_B2Bg/viewform">this form</Link>. </p>
   },
   [FAQPageOptionId.HOW_OFTEN_IS_SEROTRACKER_DATA_UPDATED]: {
     label: 'How often is SeroTracker data updated?',
@@ -21,7 +21,7 @@ export const faqPageText: Record<FAQPageOptionId, {label: string, content: JSX.E
   },
   [FAQPageOptionId.WHERE_DOES_ARBOTRACKER_DATA_COME_FROM]: {
     label: 'How often is ArboTracker data updated?',
-    content: <p className='inline'> We conducted a search for published articles on March 13, 2023 of several databases including Web of Science, Google Scholar, LILACS, and PubMed. We aim to update our search to include unpublished grey literature in May 2024. In addition, anyone can submit sources for us to screen and include in our review by filling out <Link className="inline text-link underline" target="_blank" href='https://forms.gle/pKNiMiMYr6hiKnXx8'>this form</Link>.</p>
+    content: <p className='inline'> We conducted a search for published articles on March 13, 2023 of several databases including Web of Science, Google Scholar, LILACS, and PubMed. We aim to update our search to include unpublished grey literature in May 2024. In addition, anyone can submit sources for us to screen and include in our review by filling out <Link className="inline text-link underline" target="_blank" rel="noopener noreferrer" href='https://forms.gle/pKNiMiMYr6hiKnXx8'>this form</Link>.</p>
   },
   [FAQPageOptionId.HOW_IS_THE_DATA_EXTRACTED_FROM_THE_SOURCES]: {
     label: 'How is the data extracted from sources?',
@@ -33,10 +33,10 @@ export const faqPageText: Record<FAQPageOptionId, {label: string, content: JSX.E
   },
   [FAQPageOptionId.HOW_DOES_ARBOTRACKER_DATA_SHOW_UP_ON_THE_MAP]: {
     label: 'How does ArboTracker data show up on the map?',
-    content: <p className='inline'> Data inputted into Airtable is automatically run through a software pipeline that cleans it and computes additional information (e.g. a study’s geographic coordinates). The outputs of the pipeline are then stored in a separate database, which is queried by <Link className="inline text-link underline" target="_blank" href="https://serotracker.vercel.app/">serotracker.vercel.app</Link> to serve the map, data tables, and data visualizations. Our data pipeline code is open source and can be found <Link className="inline text-link underline" target="_blank" href="https://github.com/serotracker/iit-backend-v2">here</Link>. </p>
+    content: <p className='inline'> Data inputted into Airtable is automatically run through a software pipeline that cleans it and computes additional information (e.g. a study’s geographic coordinates). The outputs of the pipeline are then stored in a separate database, which is queried by <Link className="inline text-link underline" target="_blank" rel="noopener noreferrer" href="https://serotracker.vercel.app/">serotracker.vercel.app</Link> to serve the map, data tables, and data visualizations. Our data pipeline code is open source and can be found <Link className="inline text-link underline" target="_blank" rel="noopener noreferrer" href="https://github.com/serotracker/iit-backend-v2">here</Link>. </p>
   },
   [FAQPageOptionId.CAN_I_DOWNLOAD_ARBOTRACKER_DATA_FOR_MY_OWN_ANALYSIS]: {
     label: 'Can I download ArboTracker data for my own analysis?',
-    content: <p className='inline'> Yes, our data is open-source and free for anyone to use. Every data table on the dashboard has a button next to it that allows you to download a csv of the data in the table. <Link className="inline text-link underline" target="_blank" href="https://serotracker.vercel.app/pathogen/arbovirus/dashboard#TABLE">This is a link to the ArboTracker data table where it is possible to download a csv containing all of our arbovirus seroprevalence estimates</Link>. </p>
+    content: <p className='inline'> Yes, our data is open-source and free for anyone to use. Every data table on the dashboard has a button next to it that allows you to download a csv of the data in the table. <Link className="inline text-link underline" target="_blank" rel="noopener noreferrer" href="https://serotracker.vercel.app/pathogen/arbovirus/dashboard#TABLE">This is a link to the ArboTracker data table where it is possible to download a csv containing all of our arbovirus seroprevalence estimates</Link>. </p>
   },
 }

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -31,10 +31,6 @@ export default async function AboutPageBaseLayout (props: AboutPageBaseLayoutPro
 
   const dehydratedState = dehydrate(queryClient);
 
-  if (process.env.NEXT_PUBLIC_ABOUT_PAGE_ENABLED !== "true") {
-    return notFound();
-  }
-
   return (
     <AboutPageProvider>
       <Hydrate state={dehydratedState}>

--- a/app/pathogen/arbovirus/dashboard/(map)/MapArbovirusStudySubmissionPrompt.tsx
+++ b/app/pathogen/arbovirus/dashboard/(map)/MapArbovirusStudySubmissionPrompt.tsx
@@ -26,7 +26,7 @@ export const MapArbovirusStudySubmissionPrompt = ({
       </CardHeader>
       <CardContent className={"p-2"}>
         <p className="inline"> Are we missing an arbovirus seroprevalence study that we should include? Submit it to us via </p>
-        <Link className="inline text-link underline text-end" target="_blank" href="https://forms.gle/pKNiMiMYr6hiKnXx8">this form</Link>
+        <Link className="inline text-link underline text-end" target="_blank" rel="noopener noreferrer" href="https://forms.gle/pKNiMiMYr6hiKnXx8">this form</Link>
         
       </CardContent>
     </Card>

--- a/components/customs/header.tsx
+++ b/components/customs/header.tsx
@@ -163,7 +163,7 @@ export const Header = () => {
               </div>
             </NavigationMenuContent>
           </NavigationMenuItem>
-          {process.env.NEXT_PUBLIC_ABOUT_PAGE_ENABLED && <NavigationMenuItem>
+          <NavigationMenuItem>
             <NavigationMenuTrigger className="bg-transparent">
               About
             </NavigationMenuTrigger>
@@ -172,7 +172,7 @@ export const Header = () => {
                 <TabGroup title={"About"} navItems={aboutNavItems} />
               </div>
             </NavigationMenuContent>
-          </NavigationMenuItem>}
+          </NavigationMenuItem>
         </NavigationMenuList>
         <NavigationMenuViewport
           className={cn("transition-colors duration-300", headerBgColor)}


### PR DESCRIPTION
Part of #231. Just some slight copy revisions from the copy document for this page. Nothing too serious :)

I'm also turning the about page on in production in this PR so that we have less to remember to do when we start linking people over to this dashboard.