### PR TITLE
The estimate id column is only fixed in the table at the lg breakpoint and above (responsive design for mobile)

### DIFF
--- a/components/ui/data-table/use-data-table-styles.tsx
+++ b/components/ui/data-table/use-data-table-styles.tsx
@@ -19,7 +19,7 @@ export const useDataTableStyles = <TData, TValue>(input: useDataStylesInput<TDat
     const { columnId } = input;
 
     const baseClassnameForHeader = "border-b bg-white whitespace-nowrap";
-    const classnameForLeftColumnFixation = "sticky left-0 border-r";
+    const classnameForLeftColumnFixation = "lg:sticky lg:left-0 lg:border-r";
 
     const columnDefinition = columns.find((column) => column.accessorKey === columnId);
 
@@ -36,7 +36,7 @@ export const useDataTableStyles = <TData, TValue>(input: useDataStylesInput<TDat
     const { columnId } = input;
 
     const baseClassnameForHeader = "border-b bg-white group-hover:bg-zinc-100 whitespace-nowrap";
-    const classnameForLeftColumnFixation = "sticky left-0 border-r";
+    const classnameForLeftColumnFixation = "lg:sticky lg:left-0 lg:border-r";
 
     const columnDefinition = columns.find((column) => column.accessorKey === columnId);
 


### PR DESCRIPTION
Part of #226.

![Peek 2024-03-31 15-37](https://github.com/serotracker/dashboard/assets/86806388/074e717a-2180-4a7a-9163-229014ba4537)
