### PR TITLE
Added hover button effects to all the buttons in the visualization header

### DIFF
--- a/app/pathogen/arbovirus/dashboard/(visualizations)/visualization-header.tsx
+++ b/app/pathogen/arbovirus/dashboard/(visualizations)/visualization-header.tsx
@@ -57,7 +57,7 @@ interface AllButtonConfigurations {
 const DownloadButton = (props: DownloadButtonProps) => (
   <button
     id={props.configuration.id}
-    className="mr-4"
+    className="mr-2 p-2 hover:bg-gray-100 rounded-full"
     onClick={() => props.downloadVisualization()}
     aria-label="Download visualization"
     title="Download visualization"
@@ -69,7 +69,7 @@ const DownloadButton = (props: DownloadButtonProps) => (
 const CloseButton = (props: CloseButtonProps) => (
   <button
     id={props.configuration.id}
-    className="mr-4"
+    className="mr-2 p-2 hover:bg-gray-100 rounded-full"
     hidden={
       !props.configuration.referrerRoute ||
       !isSafeReferrerLink(props.configuration.referrerRoute)
@@ -103,6 +103,7 @@ const ZoomInButton = (props: ZoomInButtonProps) => (
     }
     aria-label="See visualization in fullscreen"
     title="See visualization in fullscreen"
+    className="p-2 hover:bg-gray-100 rounded-full"
   >
     <ZoomIn />
   </button>


### PR DESCRIPTION
Resolves #263. Added hover button effects to all the buttons in the visualization header.

![Peek 2024-04-07 13-31](https://github.com/serotracker/dashboard/assets/86806388/43ff11e0-5a2b-4810-8908-ba101e592615)
