### PR TITLE
Fixed the sampling end date filter

### DIFF
--- a/contexts/pathogen-context/filter-update-steps/apply-new-selected-filters.tsx
+++ b/contexts/pathogen-context/filter-update-steps/apply-new-selected-filters.tsx
@@ -77,8 +77,8 @@ export function filterData(
             return true; // Handle invalid date
           }
 
-          const itemStartDate = new Date(item.samplingStartDate);
-          let itemEndDate = new Date(item.samplingEndDate);
+          const itemStartDate = new Date(item.sampleStartDate);
+          const itemEndDate = new Date(item.sampleEndDate);
 
           // Check for any overlap in the sampling period
           return (
@@ -92,8 +92,8 @@ export function filterData(
             return true; // Handle invalid date
           }
 
-          const itemStartDate = new Date(item.sampleStartDate);
-          const itemEndDate = new Date(item.sampleEndDate);
+          const itemStartDate = new Date(item.samplingStartDate);
+          const itemEndDate = new Date(item.samplingEndDate);
 
           // Check for any overlap in the sampling period
           return (


### PR DESCRIPTION
Fixed the sampling end date filter in both ArboTracker and SC2Tracker. Resolves #354

![image](https://github.com/serotracker/dashboard/assets/86806388/6870139c-02cb-43bd-9e3d-5c00f2bb9e8b)
![Peek 2024-06-06 13-27](https://github.com/serotracker/dashboard/assets/86806388/5f1788bd-66f1-404b-b47d-200facfdc68f)
