### PR TITLE
Added a setting to disable and enable scatter points on the modelled seroprevalence graph.

### DIFF
--- a/app/pathogen/arbovirus/dashboard/(visualizations)/visualizations-section.tsx
+++ b/app/pathogen/arbovirus/dashboard/(visualizations)/visualizations-section.tsx
@@ -47,7 +47,7 @@ export const ArbovirusVisualizationsSection = () => {
     ArbovirusVisualizationId.MEDIAN_SEROPREVALENCE_BY_WHO_REGION_AND_AGE_GROUP
   ].includes(visualizationInfo.id));
 
-  const renderVisualizationList = useCallback((visualizationList: Array<ArbovirusVisualizationInformation & {className: string}>) => {
+  const renderVisualizationList = useCallback(<TDropdownOption extends string>(visualizationList: Array<ArbovirusVisualizationInformation<TDropdownOption> & {className: string}>) => {
     return visualizationList.map((visualizationInformation) => (
       <RechartsVisualization
         key={visualizationInformation.id}

--- a/app/pathogen/arbovirus/visualizations/visualization-page-config.tsx
+++ b/app/pathogen/arbovirus/visualizations/visualization-page-config.tsx
@@ -50,10 +50,11 @@ export enum ArbovirusVisualizationUrlParameter {
   "country-seroprevalence-comparison-scatter-plot" = "country-seroprevalence-comparison-scatter-plot",
 }
 
-export type ArbovirusVisualizationInformation = VisualizationInformation<
+export type ArbovirusVisualizationInformation<TDropdownOption extends string> = VisualizationInformation<
   ArbovirusVisualizationId,
   ArbovirusVisualizationUrlParameter,
-  ArbovirusEstimate
+  ArbovirusEstimate,
+  TDropdownOption
 >;
 
 export const isArbovirusVisualizationUrlParameter = (
@@ -61,7 +62,7 @@ export const isArbovirusVisualizationUrlParameter = (
 ): visualizationUrlParameter is ArbovirusVisualizationUrlParameter =>
   Object.values(ArbovirusVisualizationUrlParameter).some((element) => element === visualizationUrlParameter);
 
-export const arbovirusVisualizationInformation: Record<ArbovirusVisualizationId, ArbovirusVisualizationInformation> = {
+export const arbovirusVisualizationInformation: Record<ArbovirusVisualizationId, ArbovirusVisualizationInformation<string>> = {
   [ArbovirusVisualizationId.CUMULATIVE_ESTIMATE_COUNT_OVER_TIME_BY_ARBOVIRUS]: {
     id: ArbovirusVisualizationId.CUMULATIVE_ESTIMATE_COUNT_OVER_TIME_BY_ARBOVIRUS,
     urlParameter:

--- a/app/pathogen/generic-pathogen-visualizations-page.tsx
+++ b/app/pathogen/generic-pathogen-visualizations-page.tsx
@@ -3,6 +3,7 @@ import { NotFound } from "../not-found";
 import { RechartsVisualization } from "@/components/customs/visualizations/recharts-visualization";
 import { typedObjectEntries } from "@/lib/utils";
 import { GetUrlParameterFromVisualizationIdFunction } from "@/components/customs/visualizations/visualization-header";
+import { UseModalInput } from "@/components/ui/modal/modal";
 
 interface GetDisplayNameInput<TEstimate extends Record<string, unknown>> {
   data: TEstimate[]
@@ -17,13 +18,15 @@ interface RenderVisualizationInput<TEstimate extends Record<string, unknown>> {
 export interface VisualizationInformation<
   TVisualizationId extends string,
   TVisualizationUrlParameter extends string,
-  TEstimate extends Record<string, unknown>
+  TEstimate extends Record<string, unknown>,
+  TDropdownOption extends string
 > {
   id: TVisualizationId;
   urlParameter: TVisualizationUrlParameter;
   getDisplayName: (input: GetDisplayNameInput<TEstimate>) => string;
   titleTooltipContent?: string | React.ReactNode;
   renderVisualization: (input: RenderVisualizationInput<TEstimate>) => React.ReactNode;
+  customizationModalConfiguration?: UseModalInput<TDropdownOption>;
 }
 
 interface FiltersComponentProps {
@@ -34,13 +37,15 @@ type AddVisualizationInformationInput<
   TVisualizationId extends string,
   TVisualizationUrlParameter extends string,
   TEstimate extends Record<string, unknown>,
-  TNewInformation extends Record<string, unknown>
+  TNewInformation extends Record<string, unknown>,
+  TDropdownOption extends string
 > = {
   additionalInformation: Record<TVisualizationId, TNewInformation>;
   allVisualizationInformation: Record<TVisualizationId, VisualizationInformation<
     TVisualizationId,
     TVisualizationUrlParameter,
-    TEstimate
+    TEstimate,
+    TDropdownOption
   >>;
 }
 
@@ -48,30 +53,35 @@ type AddVisualizationInformationOutput<
   TVisualizationId extends string,
   TVisualizationUrlParameter extends string,
   TEstimate extends Record<string, unknown>,
-  TNewInformation extends Record<string, unknown>
+  TNewInformation extends Record<string, unknown>,
+  TDropdownOption extends string
 > = (TNewInformation & VisualizationInformation<
   TVisualizationId,
   TVisualizationUrlParameter,
-  TEstimate
+  TEstimate,
+  TDropdownOption
 >)[];
 
 export const addToVisualizationInformation = <
   TVisualizationId extends string,
   TVisualizationUrlParameter extends string,
   TEstimate extends Record<string, unknown>,
-  TNewInformation extends Record<string, unknown>
+  TNewInformation extends Record<string, unknown>,
+  TDropdownOption extends string
 >(
   input: AddVisualizationInformationInput<
     TVisualizationId,
     TVisualizationUrlParameter,
     TEstimate,
-    TNewInformation
+    TNewInformation,
+    TDropdownOption
   >
 ): AddVisualizationInformationOutput<
   TVisualizationId,
   TVisualizationUrlParameter,
   TEstimate,
-  TNewInformation
+  TNewInformation,
+  TDropdownOption
 > => {
   return typedObjectEntries(input.additionalInformation).map(([key, value]) => ({
     ...input.allVisualizationInformation[key],
@@ -82,13 +92,19 @@ export const addToVisualizationInformation = <
 interface GenericPathogenVisualizationsPageProps<
   TVisualizationId extends string,
   TVisualizationUrlParameter extends string,
-  TEstimate extends Record<string, unknown>
+  TEstimate extends Record<string, unknown>,
+  TDropdownOption extends string
 > {
   data: TEstimate[];
   isValidVisualizationUrlParameter:
     (visualizationUrlParameter: string) => visualizationUrlParameter is TVisualizationUrlParameter;
   getVisualizationInformationFromVisualizationUrlParameter:
-    (visualizationUrlParameter: TVisualizationUrlParameter) => VisualizationInformation<TVisualizationId, TVisualizationUrlParameter, TEstimate> | undefined;
+    (visualizationUrlParameter: TVisualizationUrlParameter) => VisualizationInformation<
+      TVisualizationId,
+      TVisualizationUrlParameter,
+      TEstimate,
+      TDropdownOption
+    > | undefined;
   filtersComponent: (props: FiltersComponentProps) => React.ReactNode;
   getUrlParameterFromVisualizationId: GetUrlParameterFromVisualizationIdFunction<TVisualizationId, TVisualizationUrlParameter>;
 }
@@ -96,11 +112,13 @@ interface GenericPathogenVisualizationsPageProps<
 export const GenericPathogenVisualizationsPage = <
   TVisualizationId extends string,
   TVisualizationUrlParameter extends string,
-  TEstimate extends Record<string, unknown>
+  TEstimate extends Record<string, unknown>,
+  TDropdownOption extends string
 >(props: GenericPathogenVisualizationsPageProps<
   TVisualizationId,
   TVisualizationUrlParameter,
-  TEstimate
+  TEstimate,
+  TDropdownOption
 >):React.ReactNode => {
   const searchParams = useSearchParams();
   const visualizationUrlParameter = searchParams.get('visualization');

--- a/app/pathogen/mers/dashboard/(visualizations)/visualizations-section.tsx
+++ b/app/pathogen/mers/dashboard/(visualizations)/visualizations-section.tsx
@@ -20,7 +20,7 @@ export const MersVisualizationsSection = () => {
 
   const { filteredData } = useContext(MersContext);
 
-  const renderVisualizationList = useCallback((visualizationList: Array<MersVisualizationInformation & {className: string}>) => {
+  const renderVisualizationList = useCallback(<TDropdownOption extends string>(visualizationList: Array<MersVisualizationInformation<TDropdownOption> & {className: string}>) => {
     return visualizationList.map((visualizationInformation) => (
       <RechartsVisualization
         key={visualizationInformation.id}

--- a/app/pathogen/mers/visualizations/visualization-page-config.tsx
+++ b/app/pathogen/mers/visualizations/visualization-page-config.tsx
@@ -18,10 +18,11 @@ export enum MersVisualizationUrlParameter {
   "placeholder" = "placeholder"
 }
 
-export type MersVisualizationInformation = VisualizationInformation<
+export type MersVisualizationInformation<TDropdownOption extends string> = VisualizationInformation<
   MersVisualizationId,
   MersVisualizationUrlParameter,
-  MersEstimate
+  MersEstimate,
+  TDropdownOption
 >;
 
 export const isMersVisualizationUrlParameter = (
@@ -29,7 +30,7 @@ export const isMersVisualizationUrlParameter = (
 ): visualizationUrlParameter is MersVisualizationUrlParameter =>
   Object.values(MersVisualizationUrlParameter).some((element) => element === visualizationUrlParameter);
 
-export const mersVisualizationInformation: Record<MersVisualizationId, MersVisualizationInformation> = {
+export const mersVisualizationInformation: Record<MersVisualizationId, MersVisualizationInformation<string>> = {
   [MersVisualizationId.PLACEHOLDER]: {
     id: MersVisualizationId.PLACEHOLDER,
     urlParameter:

--- a/app/pathogen/sarscov2/dashboard/(visualizations)/modelled-seroprevalence-by-who-region.tsx
+++ b/app/pathogen/sarscov2/dashboard/(visualizations)/modelled-seroprevalence-by-who-region.tsx
@@ -18,6 +18,7 @@ const barColoursForWhoRegions: Record<WhoRegion, string> = {
 };
 
 interface ModelledSeroprevalenceByWhoRegionGraphProps {
+  scatterPointsVisible: boolean;
   legendConfiguration: LegendConfiguration;
 }
 
@@ -64,6 +65,7 @@ export const ModelledSeroprevalenceByWhoRegionGraph = (props: ModelledSeropreval
     <LineChartWithBestFitCurveAndScatterPoints
       graphId="modelled-sc2-seroprevalence-by-who-region"
       data={ungroupedDataPoints}
+      scatterPointsVisible={props.scatterPointsVisible}
       xAxisValueToLabel={(xAxisValue) => monthCountToMonthYearString(xAxisValue)}
       primaryGroupingFunction={(dataPoint) => dataPoint.whoRegion}
       primaryGroupingSortFunction={(whoRegionA, whoRegionB) => whoRegionA > whoRegionB ? 1 : -1}

--- a/app/pathogen/sarscov2/dashboard/(visualizations)/modelled-seroprevalence-by-who-region/use-modelled-seroprevalence-by-who-region-customization-modal.tsx
+++ b/app/pathogen/sarscov2/dashboard/(visualizations)/modelled-seroprevalence-by-who-region/use-modelled-seroprevalence-by-who-region-customization-modal.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { ModalState, ModalType, UseModalInput } from "@/components/ui/modal/modal";
+import { CustomizationSettingType } from "@/components/ui/modal/customization-modal/customization-settings";
+
+interface UseModelledSeroprevalenceByWhoRegionCustomizationModalOutput {
+  customizationModalConfiguration: UseModalInput<string>
+  customizationSettings: {
+    modelledSeroprevalenceByWhoRegionScatterPointsVisible: boolean;
+  }
+}
+
+export const useModelledSeroprevalenceByWhoRegionCustomizationModal = (): UseModelledSeroprevalenceByWhoRegionCustomizationModalOutput => {
+  const [
+    modelledSeroprevalenceByWhoRegionScatterPointsVisible,
+    setModelledSeroprevalenceByWhoRegionScatterPointsVisible
+  ] = useState<boolean>(false);
+
+  const customizationModalConfiguration: UseModalInput<string> = {
+    initialModalState: ModalState.CLOSED,
+    disabled: false,
+    modalType: ModalType.CUSTOMIZATION_MODAL,
+    content: {
+      customizationSettings: [{
+        type: CustomizationSettingType.SWITCH,
+        switchName: `Scatter points ${modelledSeroprevalenceByWhoRegionScatterPointsVisible ? 'visible' : 'not visible'}.`,
+        switchValue: modelledSeroprevalenceByWhoRegionScatterPointsVisible,
+        onSwitchValueChange: (newSwitchValue: boolean) => setModelledSeroprevalenceByWhoRegionScatterPointsVisible(newSwitchValue),
+      }]
+    }
+  }
+
+  return {
+    customizationModalConfiguration,
+    customizationSettings: {
+      modelledSeroprevalenceByWhoRegionScatterPointsVisible
+    }
+  }
+}

--- a/app/pathogen/sarscov2/dashboard/(visualizations)/visualizations-section.tsx
+++ b/app/pathogen/sarscov2/dashboard/(visualizations)/visualizations-section.tsx
@@ -3,10 +3,12 @@ import { cn } from '@/lib/utils';
 import { RechartsVisualization } from "../../../../../components/customs/visualizations/recharts-visualization";
 import { DashboardSectionId } from "@/app/pathogen/generic-pathogen-dashboard-page";
 import { addToVisualizationInformation } from "@/app/pathogen/generic-pathogen-visualizations-page";
-import { SarsCov2VisualizationId, SarsCov2VisualizationInformation, getUrlParameterFromVisualizationId, sarsCov2VisualizationInformation } from "../../visualizations/visualization-page-config";
+import { SarsCov2VisualizationId, SarsCov2VisualizationInformation, getUrlParameterFromVisualizationId, useVisualizationPageConfiguration } from "../../visualizations/visualization-page-config";
 import { SarsCov2Context } from "@/contexts/pathogen-context/pathogen-contexts/sarscov2/sc2-context";
 
 export const SarsCov2VisualizationsSection = () => {
+  const { sarsCov2VisualizationInformation } = useVisualizationPageConfiguration();
+
   const allVisualizationInformationWithClassnames = addToVisualizationInformation({
     additionalInformation: {
       [SarsCov2VisualizationId.PUBLISHED_STUDY_COUNT_BY_GBD_REGION]: { className: "h-full-screen" },
@@ -28,7 +30,7 @@ export const SarsCov2VisualizationsSection = () => {
 
   const { filteredData } = useContext(SarsCov2Context);
 
-  const renderVisualizationList = useCallback((visualizationList: Array<SarsCov2VisualizationInformation & {className: string}>) => {
+  const renderVisualizationList = useCallback(<TDropdownOption extends string>(visualizationList: Array<SarsCov2VisualizationInformation<TDropdownOption> & {className: string}>) => {
     return visualizationList.map((visualizationInformation) => (
       <RechartsVisualization
         key={visualizationInformation.id}

--- a/app/pathogen/sarscov2/visualizations/page.tsx
+++ b/app/pathogen/sarscov2/visualizations/page.tsx
@@ -6,12 +6,13 @@ import { SarsCov2Filters } from "../dashboard/filters";
 import { 
   getUrlParameterFromVisualizationId,
   isSarsCov2VisualizationUrlParameter,
-  sarsCov2VisualizationInformationArray
+  useVisualizationPageConfiguration
 } from "./visualization-page-config";
 import { Suspense, useContext } from "react";
 
 export default function VisualizationsPage() {
   const { filteredData } = useContext(SarsCov2Context);
+  const { sarsCov2VisualizationInformationArray } = useVisualizationPageConfiguration();
 
   return (
     <Suspense>

--- a/app/pathogen/sarscov2/visualizations/visualization-page-config.tsx
+++ b/app/pathogen/sarscov2/visualizations/visualization-page-config.tsx
@@ -9,6 +9,7 @@ import { CumulativeNumberOfSerosurveysPublishedOverTime } from "../dashboard/(vi
 import { ModelledSeroprevalenceByWhoRegionGraph } from "../dashboard/(visualizations)/modelled-seroprevalence-by-who-region";
 import { ComparingSeroprevalencePositiveCasesAndVaccinationsOverTime } from "../dashboard/(visualizations)/comparing-seroprevalence-positive-cases-and-vaccinations-over-time";
 import { NumberOfInfectionsPerConfirmedCaseAtTheStudyMidpointByGbdSuperRegion } from "../dashboard/(visualizations)/number-of-infections-at-midpoint-by-gbd-region";
+import { useModelledSeroprevalenceByWhoRegionCustomizationModal } from "../dashboard/(visualizations)/modelled-seroprevalence-by-who-region/use-modelled-seroprevalence-by-who-region-customization-modal";
 
 export enum SarsCov2VisualizationId {
   PUBLISHED_STUDY_COUNT_BY_GBD_REGION = "PUBLISHED_STUDY_COUNT_BY_GBD_REGION",
@@ -31,10 +32,11 @@ export enum SarsCov2VisualizationUrlParameter {
   "number-of-infections-at-midpoint-by-gbd-region" = "number-of-infections-at-midpoint-by-gbd-region"
 }
 
-export type SarsCov2VisualizationInformation = VisualizationInformation<
+export type SarsCov2VisualizationInformation<TDropdownOption extends string> = VisualizationInformation<
   SarsCov2VisualizationId,
   SarsCov2VisualizationUrlParameter,
-  SarsCov2Estimate
+  SarsCov2Estimate,
+  TDropdownOption
 >;
 
 export const isSarsCov2VisualizationUrlParameter = (
@@ -42,7 +44,7 @@ export const isSarsCov2VisualizationUrlParameter = (
 ): visualizationUrlParameter is SarsCov2VisualizationUrlParameter =>
   Object.values(SarsCov2VisualizationUrlParameter).some((element) => element === visualizationUrlParameter);
 
-export const sarsCov2VisualizationInformation: Record<SarsCov2VisualizationId, SarsCov2VisualizationInformation> = {
+const sarsCov2VisualizationInformation: Record<SarsCov2VisualizationId, SarsCov2VisualizationInformation<string>> = {
   [SarsCov2VisualizationId.PUBLISHED_STUDY_COUNT_BY_GBD_REGION]: {
     id: SarsCov2VisualizationId.PUBLISHED_STUDY_COUNT_BY_GBD_REGION,
     urlParameter:
@@ -68,7 +70,7 @@ export const sarsCov2VisualizationInformation: Record<SarsCov2VisualizationId, S
         "modelled-seroprevalence-by-who-region"
       ],
     getDisplayName: () => "Modelled Seroprevalence Globally by WHO Region",
-    renderVisualization: () => ModelledSeroprevalenceByWhoRegionGraph({legendConfiguration: LegendConfiguration.RIGHT_ALIGNED})
+    renderVisualization: () => <p> Requires state. Initialized in following step. </p>
   },
   [SarsCov2VisualizationId.COMPARING_SEROPREVALENCE_POSITIVE_CASES_AND_VACCINATIONS]: {
     id: SarsCov2VisualizationId.COMPARING_SEROPREVALENCE_POSITIVE_CASES_AND_VACCINATIONS,
@@ -90,7 +92,35 @@ export const sarsCov2VisualizationInformation: Record<SarsCov2VisualizationId, S
   },
 }
 
-export const sarsCov2VisualizationInformationArray = typedObjectEntries(sarsCov2VisualizationInformation).map(([_, value]) => value);
+export const useVisualizationPageConfiguration = () => {
+  const modelledSeroprevalenceByWhoRegionCustomizationModal = useModelledSeroprevalenceByWhoRegionCustomizationModal();
+
+  const sarsCov2VisualizationInformationWithModalConfiguration = {
+    [SarsCov2VisualizationId.PUBLISHED_STUDY_COUNT_BY_GBD_REGION]:
+      sarsCov2VisualizationInformation[SarsCov2VisualizationId.PUBLISHED_STUDY_COUNT_BY_GBD_REGION],
+    [SarsCov2VisualizationId.CUMULATIVE_NUMBER_OF_SEROSURVEYS_PUBLISHED_OVER_TIME]:
+      sarsCov2VisualizationInformation[SarsCov2VisualizationId.CUMULATIVE_NUMBER_OF_SEROSURVEYS_PUBLISHED_OVER_TIME],
+    [SarsCov2VisualizationId.MODELLED_SEROPREVALENCE_BY_WHO_REGION]: {
+      ...sarsCov2VisualizationInformation[SarsCov2VisualizationId.MODELLED_SEROPREVALENCE_BY_WHO_REGION],
+      customizationModalConfiguration: modelledSeroprevalenceByWhoRegionCustomizationModal.customizationModalConfiguration,
+      renderVisualization: () => ModelledSeroprevalenceByWhoRegionGraph({
+        legendConfiguration: LegendConfiguration.RIGHT_ALIGNED,
+        scatterPointsVisible: modelledSeroprevalenceByWhoRegionCustomizationModal.customizationSettings.modelledSeroprevalenceByWhoRegionScatterPointsVisible
+      }),
+    },
+    [SarsCov2VisualizationId.COMPARING_SEROPREVALENCE_POSITIVE_CASES_AND_VACCINATIONS]:
+      sarsCov2VisualizationInformation[SarsCov2VisualizationId.COMPARING_SEROPREVALENCE_POSITIVE_CASES_AND_VACCINATIONS],
+    [SarsCov2VisualizationId.NUMBER_OF_INFECTIONS_AT_MIDPOINT_BY_GBD_REGION]:
+      sarsCov2VisualizationInformation[SarsCov2VisualizationId.NUMBER_OF_INFECTIONS_AT_MIDPOINT_BY_GBD_REGION],
+  } as const;
+
+  return {
+    sarsCov2VisualizationInformation: sarsCov2VisualizationInformationWithModalConfiguration,
+    sarsCov2VisualizationInformationArray:
+      typedObjectEntries(sarsCov2VisualizationInformationWithModalConfiguration).map(([_, value]) => value)
+  }
+}
+
 export const getUrlParameterFromVisualizationId: GetUrlParameterFromVisualizationIdFunction<
   SarsCov2VisualizationId,
   SarsCov2VisualizationUrlParameter

--- a/components/customs/visualizations/line-chart-with-best-fit-curve-and-scatter-points.tsx
+++ b/components/customs/visualizations/line-chart-with-best-fit-curve-and-scatter-points.tsx
@@ -37,6 +37,7 @@ interface LineChartWithBestFitCurveAndScatterPointsProps<
   xAxisValueToLabel?: (input: number) => string;
   allPrimaryGroups?: TPrimaryGroupingKey[];
   getLineColour: (secondaryKey: TPrimaryGroupingKey, index: number) => string;
+  scatterPointsVisible: boolean;
   percentageFormattingEnabled?: boolean;
   legendConfiguration: LegendConfiguration;
 }
@@ -151,7 +152,7 @@ export const LineChartWithBestFitCurveAndScatterPoints = <
             stroke={props.getLineColour(primaryKey, index)}
           />
         ))}
-        {allPrimaryKeys.map((primaryKey, index) => (
+        {props.scatterPointsVisible && allPrimaryKeys.map((primaryKey, index) => (
           <Scatter
             legendType='none'
             name={`${primaryKey} (Raw)`}

--- a/components/customs/visualizations/line-chart-with-best-fit-curve-and-scatter-points.tsx
+++ b/components/customs/visualizations/line-chart-with-best-fit-curve-and-scatter-points.tsx
@@ -84,10 +84,17 @@ export const LineChartWithBestFitCurveAndScatterPoints = <
     }
   )
 
-  const tooltipFormatter: TooltipFormatter<number, string> = (value, name) => [
-    `${value.toFixed(2)}%`,
-    name
-  ];
+  const tooltipFormatter: TooltipFormatter<number, string> = props.scatterPointsVisible 
+    ? (value, name) => [
+      `${value.toFixed(2)}%`,
+      name
+    ]
+    : (value, name) => [
+      `${value.toFixed(2)}%`,
+      name
+        .replace(/ \(Modelled\)$/g, '')
+        .replace(/ \(Raw\)$/g, '')
+    ];
 
   const legendFormatter: LegendFormatter = (name: string) => (
     name

--- a/components/customs/visualizations/visualization-header.tsx
+++ b/components/customs/visualizations/visualization-header.tsx
@@ -120,6 +120,7 @@ const ZoomInButton = <
 
 const CustomizeButton = (props: CustomizeButtonProps) => (
   <button
+    id={props.configuration.id}
     aria-label="Customize Visualization"
     title="Customize Visualization"
     className="mr-2 p-2 hover:bg-gray-100 rounded-full"

--- a/components/customs/visualizations/visualization-header.tsx
+++ b/components/customs/visualizations/visualization-header.tsx
@@ -1,14 +1,12 @@
-import { ZoomIn, DownloadCloud, X } from "lucide-react";
+import { ZoomIn, DownloadCloud, X, Settings } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { isSafeReferrerLink } from "@/utils/referrer-link-util";
-import { useContext } from "react";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { ArboContext } from "@/contexts/pathogen-context/pathogen-contexts/arbovirus/arbo-context";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { VisualizationInformation } from "@/app/pathogen/generic-pathogen-visualizations-page";
 
@@ -27,6 +25,7 @@ export type ButtonConfig<AdditionalButtonInformation> =
 export type ZoomInButtonAdditionalButtonConfig = { referrerRoute: string };
 export type DownloadButtonAdditionalButtonConfig = {};
 export type CloseButtonAdditionalButtonConfig = { referrerRoute: string | undefined | null };
+export type CustomizeButtonAdditionalButtonConfig = { onClick: () => void };
 
 export type GetUrlParameterFromVisualizationIdFunction<TVisualizationId extends string, TVisualizationUrlParameter extends string> =
   (input: {visualizationId: TVisualizationId}) => {urlParameter: TVisualizationUrlParameter};
@@ -48,10 +47,15 @@ interface CloseButtonProps {
   router: AppRouterInstance;
 }
 
+interface CustomizeButtonProps {
+  configuration: EnabledButtonConfig<CustomizeButtonAdditionalButtonConfig> & { id: string };
+}
+
 interface AllButtonConfigurations {
   zoomInButton: ButtonConfig<ZoomInButtonAdditionalButtonConfig> & { id: string };
   downloadButton: ButtonConfig<DownloadButtonAdditionalButtonConfig> & { id: string };
   closeButton: ButtonConfig<CloseButtonAdditionalButtonConfig> & { id: string };
+  customizeButton: ButtonConfig<CustomizeButtonAdditionalButtonConfig> & { id: string };
 }
 
 const DownloadButton = (props: DownloadButtonProps) => (
@@ -114,15 +118,28 @@ const ZoomInButton = <
   </button>
 );
 
+const CustomizeButton = (props: CustomizeButtonProps) => (
+  <button
+    aria-label="Customize Visualization"
+    title="Customize Visualization"
+    className="mr-2 p-2 hover:bg-gray-100 rounded-full"
+    onClick={() => props.configuration.onClick()}
+  >
+    <Settings />
+  </button>
+);
+
 interface VisualizationHeaderProps<
   TVisualizationId extends string,
   TVisualizationUrlParameter extends string,
-  TEstimate extends Record<string, unknown>
+  TEstimate extends Record<string, unknown>,
+  TDropdownOption extends string
 > {
   visualizationInformation: VisualizationInformation<
     TVisualizationId,
     TVisualizationUrlParameter,
-    TEstimate
+    TEstimate,
+    TDropdownOption
   >;
   data: TEstimate[];
   getUrlParameterFromVisualizationId: GetUrlParameterFromVisualizationIdFunction<TVisualizationId, TVisualizationUrlParameter>;
@@ -133,12 +150,14 @@ interface VisualizationHeaderProps<
 export const VisualizationHeader = <
   TVisualizationId extends string,
   TVisualizationUrlParameter extends string,
-  TEstimate extends Record<string, unknown>
+  TEstimate extends Record<string, unknown>,
+  TDropdownOption extends string
 >(
   props: VisualizationHeaderProps<
     TVisualizationId,
     TVisualizationUrlParameter,
-    TEstimate
+    TEstimate,
+    TDropdownOption
   >
 ) => {
   const router = useRouter();
@@ -183,6 +202,11 @@ export const VisualizationHeader = <
         <DownloadButton
           downloadVisualization={() => props.downloadVisualization()}
           configuration={props.buttonConfiguration.downloadButton}
+        />
+      )}
+      {props.buttonConfiguration.customizeButton.enabled && (
+        <CustomizeButton
+          configuration={props.buttonConfiguration.customizeButton}
         />
       )}
       {props.buttonConfiguration.closeButton.enabled && (

--- a/components/ui/modal/modal.tsx
+++ b/components/ui/modal/modal.tsx
@@ -77,7 +77,7 @@ type EnabledUseModalInput<
   disabled: false;
 } & ModalPropsBasedOnType<TDropdownOption>;
 
-type UseModalInput<
+export type UseModalInput<
   TDropdownOption extends string
 > = 
   | DisabledUseModalInput

--- a/contexts/pathogen-context/pathogen-contexts/sarscov2/modelled-sarscov2-seroprevalence-context.tsx
+++ b/contexts/pathogen-context/pathogen-contexts/sarscov2/modelled-sarscov2-seroprevalence-context.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { createContext, useContext, useEffect, useMemo } from "react";
+import { createContext, useContext, useMemo } from "react";
 import { SarsCov2Context } from "./sc2-context";
 import { useBestFitCurve } from "@/components/customs/visualizations/line-fitting/use-best-fit-curve";
 import { pipe } from "fp-ts/lib/function.js";
-import { GbdSubRegion, GbdSuperRegion, UnRegion, WhoRegion } from '@/gql/graphql';
+import { WhoRegion } from '@/gql/graphql';
 import { MonthlySarsCov2CountryInformationContext } from './monthly-sarscov2-country-information-context';
 import { filterDataForSarsCov2SeroprevalenceModelling } from './modelled-sarscov2-seroprevalence-context/data-filtering';
 import { generateCountrySeroprevalenceDataBreakdown } from './modelled-sarscov2-seroprevalence-context/country-seroprevalence-breakdown-helper';
@@ -92,10 +92,6 @@ export const ModelledSarsCov2SeroprevalenceProvider = (props: ModelledSarsCov2Se
     (input) => fitModellingCurve({ ...input, generateBestFitCurve }),
     (input) => ({ dataPoints: input.dataPoints.map((dataPoint) => ({ countryAlphaThreeCode: dataPoint.groupingKey, data: dataPoint.data }))})
   ), [ countryModelledSeroprevalenceBreakdown ]);
-
-  useEffect(() => {
-    console.log('dataPointsForWhoRegions', dataPointsForWhoRegions);
-  }, [ dataPointsForWhoRegions ])
 
   return (
     <ModelledSarsCov2SeroprevalenceContext.Provider


### PR DESCRIPTION
Added a setting to disable and enable scatter points on the modelled seroprevalence graph. Part of resolving #361.

![Peek 2024-07-07 09-46](https://github.com/serotracker/dashboard/assets/86806388/46d6001a-57e0-440e-8a67-69cfccac7170)
![modelled-seroprevalence-by-who-region(2)](https://github.com/serotracker/dashboard/assets/86806388/36808df4-f42a-4d54-8168-54a0d144123b)